### PR TITLE
Update/action

### DIFF
--- a/.github/actions/setup-and-deploy/action.yaml
+++ b/.github/actions/setup-and-deploy/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
   dockerhub_username:
     required: true
-  dockerhub_token:
+  token:
     required: true
   yc_service_account_key:
     required: true
@@ -26,8 +26,8 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
-        username: ${{ inputs.dockerhub_username }}
-        password: ${{ inputs.dockerhub_token }}
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.token }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
@@ -36,8 +36,8 @@ runs:
         file: ./Dockerfile
         push: true
         tags: |
-          ${{ inputs.registry }}/${{ inputs.image_name }}:latest
-          ${{ inputs.registry }}/${{ inputs.image_name }}:${{ github.sha }}
+          ${{ inputs.registry }}/${{ github.repository_owner }}:latest
+          ${{ inputs.registry }}/${{ github.repository_owner }}:${{ github.sha }}
 
     - name: Install yc CLI
       run: |

--- a/.github/actions/setup-and-deploy/action.yaml
+++ b/.github/actions/setup-and-deploy/action.yaml
@@ -34,8 +34,8 @@ runs:
         file: ./Dockerfile
         push: true
         tags: |
-          ${{ inputs.registry }}/${{ github.repository_owner }}:latest
-          ${{ inputs.registry }}/${{ github.repository_owner }}:${{ github.sha }}
+          ${{ inputs.registry }}/${{ github.repository }}:latest
+          ${{ inputs.registry }}/${{ github.repository }}:${{ github.sha }}
 
     - name: Install yc CLI
       run: |

--- a/.github/actions/setup-and-deploy/action.yaml
+++ b/.github/actions/setup-and-deploy/action.yaml
@@ -3,8 +3,6 @@ description: 'Common setup and deployment steps'
 inputs:
   registry:
     required: true
-  image_name:
-    required: true
   folder_id:
     required: true
   cluster_id:

--- a/.github/actions/setup-and-deploy/action.yaml
+++ b/.github/actions/setup-and-deploy/action.yaml
@@ -22,9 +22,10 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Docker Hub
+    - name: Login to Container Registry
       uses: docker/login-action@v3
       with:
+        registry: ${{ inputs.registry }}
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 


### PR DESCRIPTION
WHAT
- добавил возможность пушить образы в **github packeds**,  а не только в **docker hub**
- использую env для имени репо и владельца(организации), которые автоматом  идут с github (${{ github.name }} и не нужно их передавать